### PR TITLE
[1장 오브젝트와 의존관계] 1.4 제어의 역전 (IoC)

### DIFF
--- a/DConnectionMaker.java
+++ b/DConnectionMaker.java
@@ -1,10 +1,12 @@
 import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.SQLException;
 
 public class DConnectionMaker implements ConnectionMaker {
     @Override
     public Connection makeConnection() throws ClassNotFoundException, SQLException {
-        // Connection 생성하는 코드
-        return null;
+        Class.forName("com.mysql.cj.jdbc.Driver");
+        Connection c = DriverManager.getConnection("jdbc:mysql://localhost/springbook", "spring", "book1234");
+        return c;
     }
 }

--- a/UserDaoTest.java
+++ b/UserDaoTest.java
@@ -1,12 +1,27 @@
+import java.sql.SQLException;
+
 /**
  * 관계 설정 책임이 추가된 UserDao 클라이언트인 main 메소드
  */
 public class UserDaoTest {
-    public static void main(String[] args) {
+    public static void main(String[] args) throws SQLException, ClassNotFoundException {
         // UserDao가 사용할 ConnectionMaker 구현 클래스 DConnectionMaker
         ConnectionMaker connectionMaker = new DConnectionMaker();
 
         // DConnectionMaker와 UserDao "오브젝트 사이의" 의존관계 설정
         UserDao dao = new UserDao(connectionMaker);
+
+        User user = new User();
+        user.setId("hannkim");
+        user.setName("김한나");
+        user.setPassword("genius");
+
+        dao.add(user);
+
+        System.out.println(user.getId() + " 등록 성공");
+
+        User user2 = dao.get(user.getId());
+        System.out.println(user2.getName());
+
     }
 }

--- a/user/dao/ConnectionMaker.java
+++ b/user/dao/ConnectionMaker.java
@@ -1,3 +1,5 @@
+package user.dao;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 

--- a/user/dao/DConnectionMaker.java
+++ b/user/dao/DConnectionMaker.java
@@ -1,3 +1,5 @@
+package user.dao;
+
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;

--- a/user/dao/DaoFactory.java
+++ b/user/dao/DaoFactory.java
@@ -5,8 +5,15 @@ package user.dao;
  */
 public class DaoFactory {
     public UserDao userDao() {
-        ConnectionMaker connectionMaker = new DConnectionMaker();
-        UserDao userDao = new UserDao(connectionMaker);
-        return userDao;
+        return new UserDao(connectionMaker());
+    }
+
+    // public AccountDao accountDao() {
+    //     return new AccountDao(connectionMaker());
+    // }
+
+    // dao가 많아질 경우 중복된 코드를 분리하기 위함이다.
+    public ConnectionMaker connectionMaker() {
+        return new DConnectionMaker();
     }
 }

--- a/user/dao/DaoFactory.java
+++ b/user/dao/DaoFactory.java
@@ -1,0 +1,12 @@
+package user.dao;
+
+/**
+ * UserDao의 생성 책임을 맡은 팩토리 클래스 (의존 관계 설정)
+ */
+public class DaoFactory {
+    public UserDao userDao() {
+        ConnectionMaker connectionMaker = new DConnectionMaker();
+        UserDao userDao = new UserDao(connectionMaker);
+        return userDao;
+    }
+}

--- a/user/dao/UserDao.java
+++ b/user/dao/UserDao.java
@@ -1,7 +1,11 @@
+package user.dao;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
+import user.domain.User;
 
 public class UserDao {
     private ConnectionMaker connectionMaker;

--- a/user/dao/UserDaoTest.java
+++ b/user/dao/UserDaoTest.java
@@ -1,18 +1,22 @@
+package user.dao;
+
 import java.sql.SQLException;
 
+import user.domain.User;
+
 /**
- * 관계 설정 책임이 추가된 UserDao 클라이언트인 main 메소드
+ * 관계 설정 책임이 추가된 user.dao.UserDao 클라이언트인 main 메소드
  */
 public class UserDaoTest {
     public static void main(String[] args) throws SQLException, ClassNotFoundException {
-        // UserDao가 사용할 ConnectionMaker 구현 클래스 DConnectionMaker
+        // UserDao가 사용할 user.dao.ConnectionMaker 구현 클래스 user.dao.DConnectionMaker
         ConnectionMaker connectionMaker = new DConnectionMaker();
 
-        // DConnectionMaker와 UserDao "오브젝트 사이의" 의존관계 설정
+        // DConnectionMaker와 user.dao.UserDao "오브젝트 사이의" 의존관계 설정
         UserDao dao = new UserDao(connectionMaker);
 
         User user = new User();
-        user.setId("hannkim");
+        user.setId("hannkim1");
         user.setName("김한나");
         user.setPassword("genius");
 

--- a/user/dao/UserDaoTest.java
+++ b/user/dao/UserDaoTest.java
@@ -5,15 +5,11 @@ import java.sql.SQLException;
 import user.domain.User;
 
 /**
- * 관계 설정 책임이 추가된 user.dao.UserDao 클라이언트인 main 메소드
+ * user.dao.UserDao 클라이언트인 main 메소드
  */
 public class UserDaoTest {
     public static void main(String[] args) throws SQLException, ClassNotFoundException {
-        // UserDao가 사용할 user.dao.ConnectionMaker 구현 클래스 user.dao.DConnectionMaker
-        ConnectionMaker connectionMaker = new DConnectionMaker();
-
-        // DConnectionMaker와 user.dao.UserDao "오브젝트 사이의" 의존관계 설정
-        UserDao dao = new UserDao(connectionMaker);
+        UserDao dao = new DaoFactory().userDao();
 
         User user = new User();
         user.setId("hannkim1");

--- a/user/domain/User.java
+++ b/user/domain/User.java
@@ -1,3 +1,5 @@
+package user.domain;
+
 public class User {
     String id;
     String name;


### PR DESCRIPTION
# Issue
- #2 

# 정리
### 요약
<img width="730" alt="스크린샷 2024-08-09 오후 5 00 11" src="https://github.com/user-attachments/assets/7f0a2037-b1b4-472f-9566-49a133397fde">

`DaoFactory` 팩토리 클래스를 생성하여 기존 `UserDaoTest`에 포함되어 있던 **의존관계 설정에 대한 관심사를 분리**하였다.
`DaoFactory`를 통하여 DB Connection에 사용할 구체 클래스를 결정 및 의존 관계를 설정하고, `UserDaoTest`에서는 테스트에만 집중할 수 있게 되었다.
분리를 통해 얻은 여러 장점 중에서도 **애플리케이션의 '컴포넌트' 역할을 하는 오브젝트와 '구조'를 결정하는 오브젝트를 분리**했다는 데 가장 의미가 있다. (like 설계도 역할)


### 팩토리 (Factory)
- 객체의 생성 방법을 결정하고 그렇게 만들어진 오브젝트를 돌려주는 것
- 오브젝트를 생성하는 쪽과 생성된 오브젝트를 사용하는 쪽의 역할과 책임을 분리하려는 목적으로 사용


### 제어의 역전 (IoC)
- **모든 제어 권한을 자신이 아닌 다른 대상에게 위임**한다.
- 오브젝트가 자신이 사용할 오브젝트를 스스로 선택하지 않는다.
- 프레임워크에와 라이브러리와는 달리 제어의 역전(IoC)이 적용된다.
- 애플리케이션 컴포넌트의 생성과 관계설정, 사용, 생명주기 관리 등을 관장하는 존재가 필요하다.