### PR TITLE
[1장 오브젝트와 의존관계] 1.5 스프링의 IoC

### DIFF
--- a/user/dao/DaoFactory.java
+++ b/user/dao/DaoFactory.java
@@ -1,9 +1,14 @@
 package user.dao;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
 /**
  * UserDao의 생성 책임을 맡은 팩토리 클래스 (의존 관계 설정)
  */
+@Configuration
 public class DaoFactory {
+    @Bean
     public UserDao userDao() {
         return new UserDao(connectionMaker());
     }
@@ -13,6 +18,7 @@ public class DaoFactory {
     // }
 
     // dao가 많아질 경우 중복된 코드를 분리하기 위함이다.
+    @Bean
     public ConnectionMaker connectionMaker() {
         return new DConnectionMaker();
     }

--- a/user/dao/UserDaoTest.java
+++ b/user/dao/UserDaoTest.java
@@ -2,6 +2,9 @@ package user.dao;
 
 import java.sql.SQLException;
 
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
 import user.domain.User;
 
 /**
@@ -9,10 +12,13 @@ import user.domain.User;
  */
 public class UserDaoTest {
     public static void main(String[] args) throws SQLException, ClassNotFoundException {
-        UserDao dao = new DaoFactory().userDao();
+        ApplicationContext context = new AnnotationConfigApplicationContext(DaoFactory.class);
+
+        // generic method 방식 사용하여 두번째 파라미터에 리턴 타입(UserDao.class) 지정
+        UserDao dao = context.getBean("userDao", UserDao.class);
 
         User user = new User();
-        user.setId("hannkim1");
+        user.setId("hannkim3");
         user.setName("김한나");
         user.setPassword("genius");
 


### PR DESCRIPTION
# Issue
- #2 

# 정리
### Spring 공식문서 기반의 IoC 컨테이너와 Bean 정리
- https://mannahjjang.tistory.com/49

### 변경 사항
<img width="605" alt="스크린샷 2024-08-13 오후 5 33 49" src="https://github.com/user-attachments/assets/d261b4c3-6491-45bf-a4a5-d841b9af2c5b">

스프링의 IoC Container라 불리는 `ApplicationContext`는 `BeanFactory`를 상속한 인터페이스로, 생성정보와 연관관계 정보를 담는 별도의 configuration metadata(설정 정보)를 통해 IoC를 적용하여 빈 객체를 생성하고 관리한다.

`ApplicationContext`에 `DaoFactory` configuration metadata(구성 정보)를 `@Bean`으로 Bean 등록을 했다.
클라이언트는 `ApplicationContext`의 `getBean()`을 통해 `UserDao` 객체를 생성하고 이렇게 만들어진 'Bean 객체'는 컨테이너(`ApplicationContext`)에 의해 관리된다.

이전의 DaoFactory과 비교했을 때 ApplicationContext는 좀더 범용적이고 유연한 방법으로 IoC 기능을 확장할 수 있다.
클라이언트는 구체적인 팩토리 클래스를 알 필요가 없고, 종합 IoC 서비스를 제공해주며 빈을 검색하는 다양한 방법을 제공하는 장점이 있다.
종합 IoC 서비스는 관계설 오브젝트의 관계 설정, 오브젝트가 만들어지는 방식, 시점과 전략을 다르게 가져갈 수 있고, 부가적인 다양한 기능을 제공한다.
